### PR TITLE
Add .env and api endpoint variable

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,0 +1,1 @@
+API_ENDPOINT=

--- a/pages/album/[id].tsx
+++ b/pages/album/[id].tsx
@@ -5,9 +5,12 @@ import Header from "../../components/header";
 import Player from "../../components/player";
 import Tweet from "../../components/tweet";
 
+const API_ENDPOINT =
+  process.env.API_ENDPOINT || "https://stream-api.kitahina.co";
+
 export const getStaticPaths: GetStaticPaths = async () => {
   // https://nextjs.org/docs/basic-features/data-fetching/get-static-paths
-  const res = await fetch("https://stream-api.kitahina.co/album");
+  const res = await fetch(`${API_ENDPOINT}/album`);
   const albums = await res.json();
 
   const paths = albums.data.map((data: { id: string }) => ({
@@ -19,7 +22,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const id = context?.params?.id;
-  const res = await fetch(`https://stream-api.kitahina.co/album/${id}`);
+  const res = await fetch(`${API_ENDPOINT}/album/${id}`);
   const album = await res.json();
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,8 +4,11 @@ import Head from "next/head";
 import Link from "next/link";
 import Fuse from "fuse.js";
 
+const API_ENDPOINT =
+  process.env.API_ENDPOINT || "https://stream-api.kitahina.co";
+
 export const getStaticProps = async () => {
-  const res = await fetch("https://stream-api.kitahina.co/album");
+  const res = await fetch(`${API_ENDPOINT}/album`);
   const resJson = await res.json();
   const data = resJson.data;
 


### PR DESCRIPTION
初めまして。
楽曲の追加をしたいと思いAPIリポジトリと一緒にCloneしたのですが、エンドポイントURLが本番へ向いており少々不便だったので、開発用URLも設定できるようにしました。

## 動作確認手順
1. `.env.local.sample`を`.env.local`にコピー
2. `.env.local`の`API_ENDPONT`の値を任意のURLにする（例 http://127.0.0.1:8000 ）
3. 開発用のAPI戻り値をいじる
4. 開発環境に反映されていればOK