### PR TITLE
データ取得時の自動キャッシュを無効にする

### DIFF
--- a/app/album/[id]/page.tsx
+++ b/app/album/[id]/page.tsx
@@ -9,7 +9,8 @@ const API_ENDPOINT =
 export const dynamicParams = false;
 
 export const generateStaticParams = async () => {
-  const res = await fetch(`${API_ENDPOINT}/album`);
+  // TODO: Proper cache strategy
+  const res = await fetch(`${API_ENDPOINT}/album`, { cache: "no-store" });
   const albums = await res.json();
 
   return albums.data.map((data: { id: string }) => ({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,9 @@ export const metadata: Metadata = {
   description: "音楽ストリーミングでひろがるアイドルマスターの世界",
 };
 
+// TODO: Proper cache strategy
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({
   children,
 }: {


### PR DESCRIPTION
App Routerを使うと、APIから取ったデータをData Cacheが自動的にキャッシュしてしまう。開発環境ではとても鬱陶しいので、いったん無効にしてしまう。そのうちちゃんとキャッシュまわりをやる。